### PR TITLE
chore: release v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0](https://github.com/lrangell/phlex-emmet-lsp/compare/v0.1.0...v0.2.0) - 2025-01-05
+
+### Added
+
+- add text support
+
 ## [0.1.0](https://github.com/lrangell/phlex-emmet-lsp/releases/tag/v0.1.0) - 2025-01-03
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -830,7 +830,7 @@ checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "phlex_emmet_ls"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "async-lsp",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "phlex_emmet_ls"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 license = "MIT"
 keywords = ["lsp", "ruby", "emmet"]


### PR DESCRIPTION
## 🤖 New release
* `phlex_emmet_ls`: 0.1.0 -> 0.2.0 (⚠️ API breaking changes)

### ⚠️ `phlex_emmet_ls` breaking changes

```
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.38.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field EmmetNode.text in /tmp/.tmpcZtjyn/phlex-emmet-lsp/src/types.rs:11

--- failure type_mismatched_generic_lifetimes: type now takes a different number of generic lifetimes ---

Description:
A type now takes a different number of generic lifetime parameters. Uses of this type that name the previous number of parameters will be broken.
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.38.0/src/lints/type_mismatched_generic_lifetimes.ron
Failed in:
  Struct EmmetNodeAddBuilder (3 -> 6 lifetime params) in /tmp/.tmpcZtjyn/phlex-emmet-lsp/src/types.rs:17
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.0](https://github.com/lrangell/phlex-emmet-lsp/compare/v0.1.0...v0.2.0) - 2025-01-05

### Added

- add text support
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).