### PR TITLE
chore: release v0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.1](https://github.com/lrangell/phlex-emmet-lsp/compare/v0.3.0...v0.3.1) - 2025-01-14
+
+### Fixed
+
+- multiplier
+
+### Other
+
+- add demo
+- add readme
+
 ## [0.3.0](https://github.com/lrangell/phlex-emmet-lsp/compare/v0.2.0...v0.3.0) - 2025-01-09
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -830,7 +830,7 @@ checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "phlex_emmet_ls"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "async-lsp",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "phlex_emmet_ls"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 license = "MIT"
 keywords = ["lsp", "ruby", "emmet"]


### PR DESCRIPTION
## 🤖 New release
* `phlex_emmet_ls`: 0.3.0 -> 0.3.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.3.1](https://github.com/lrangell/phlex-emmet-lsp/compare/v0.3.0...v0.3.1) - 2025-01-14

### Fixed

- multiplier

### Other

- add demo
- add readme
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).